### PR TITLE
making text font size responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -71,7 +71,8 @@
 	.homelhs, .aboutrhs, .exprhs > ul, p {
 		color: #7F7888;
 		font-family: Georgia, 'Times New Roman', Times, serif;
-		font-size: 1.2vw;
+		/* font-size: 1.2vw; */
+		font-size: calc(0.7vw + 0.5rem);
 	}
 
 	.homelhs > p {
@@ -82,11 +83,13 @@
 		margin-left: 4.5%;
 		margin-bottom: 0;
 		font-weight: bold;
-		font-size: 2.5vw;
+		/* font-size: 2.5vw; */
+		font-size: calc(2vw + 0.5rem);
 	}
 
 	.homelhs #pronouns{
-		font-size: 1.2vw;
+		/* font-size: 1.2vw; */
+		font-size: calc(0.7vw + 0.5rem);
 	}
 
 	.homelhs #resume {
@@ -100,7 +103,8 @@
 		margin-top: 15%;
 		margin-bottom: 0;
 		font-weight: bold;
-		font-size: 2.5vw;
+		/* font-size: 2.5vw; */
+		font-size: calc(2vw + 0.5rem);
 	}
 
 	.aboutrhs > ul > p {
@@ -129,7 +133,8 @@
 		margin-top: 15%;
 		margin-bottom: 0;
 		font-weight: bold;
-		font-size: 2.5vw;
+		/* font-size: 2.5vw; */
+		font-size: calc(2vw + 0.5rem);
 	}
 
 	.exprhs {
@@ -166,6 +171,7 @@
 	.exprhs #cont {
 		margin-bottom: 0;
 		font-weight: bold;
-		font-size: 2.5vw;
+		/* font-size: 2.5vw; */
+		font-size: calc(2vw + 0.5rem);
 		margin-top: 0;
 	}


### PR DESCRIPTION
based on https://css-tricks.com/simplified-fluid-typography/
made font size for paragraphs around 18px, navbar headings around 16px and page subheadings around 36px using the calc function and rem unit 
did this for digital accessibility because vw becomes way too tiny on mobile sized screens
